### PR TITLE
Added express support to experimental apollo 4 support

### DIFF
--- a/lib/instrumentation/express-utils.js
+++ b/lib/instrumentation/express-utils.js
@@ -34,9 +34,9 @@ function getStackPath (req) {
   return join(stack)
 }
 
+// the use of middleware in Apollo4 breaks the current path retrieval mechanisms
 function getApollo4Path (req) {
-  const pathName = req?._parsedUrl?.pathname || '/'
-  return pathName
+  return req?._parsedUrl?.pathname || '/'
 }
 
 // This function is also able to extract the path from a Restify request as

--- a/lib/instrumentation/express-utils.js
+++ b/lib/instrumentation/express-utils.js
@@ -34,6 +34,11 @@ function getStackPath (req) {
   return join(stack)
 }
 
+function getApollo4Path (req) {
+  const pathName = req?._parsedUrl?.pathname || '/'
+  return pathName
+}
+
 // This function is also able to extract the path from a Restify request as
 // it's storing the route name on req.route.path as well
 function getPathFromRequest (req, useBase, usePathAsTransactionName) {
@@ -72,5 +77,6 @@ function getPathFromRequest (req, useBase, usePathAsTransactionName) {
 module.exports = {
   getPathFromRequest,
   getStackPath,
+  getApollo4Path,
   routePath
 }

--- a/lib/instrumentation/modules/@apollo/server.js
+++ b/lib/instrumentation/modules/@apollo/server.js
@@ -14,7 +14,10 @@ module.exports = function (apolloServerCore, agent, { enabled }) {
   function wrapGraphQLRequest (orig) {
     return function wrappedRunHttpQuery () {
       var trans = agent._instrumentation.currTransaction()
-      if (trans) trans._graphqlRoute = true
+      if (trans) {
+        trans._graphqlRoute = true
+        trans._apollo4 = true
+      }
       return orig.apply(this, arguments)
     }
   }

--- a/lib/instrumentation/modules/graphql.js
+++ b/lib/instrumentation/modules/graphql.js
@@ -10,6 +10,7 @@ var semver = require('semver')
 var clone = require('shallow-clone-shim')
 
 var getPathFromRequest = require('../express-utils').getPathFromRequest
+var getApollo4Path = require('../express-utils').getApollo4Path
 
 module.exports = function (graphql, agent, { version, enabled }) {
   if (!enabled) return graphql
@@ -146,7 +147,7 @@ module.exports = function (graphql, agent, { version, enabled }) {
       const trans = span.transaction
       if (trans._graphqlRoute) {
         var name = queries.length > 0 ? queries.join(', ') : 'Unknown GraphQL query'
-        if (trans.req) var path = getPathFromRequest(trans.req, true)
+        if (trans.req) var path = trans._apollo4 ? getApollo4Path(trans.req) : getPathFromRequest(trans.req, true)
         var defaultName = name
         defaultName = path ? defaultName + ' (' + path + ')' : defaultName
         defaultName = operationName ? operationName + ' ' + defaultName : defaultName

--- a/test/instrumentation/express-utils.test.js
+++ b/test/instrumentation/express-utils.test.js
@@ -8,7 +8,7 @@
 
 const test = require('tape')
 
-const { getPathFromRequest } = require('../../lib/instrumentation/express-utils')
+const { getPathFromRequest, getApollo4Path } = require('../../lib/instrumentation/express-utils')
 
 test('#getPathFromRequest', function (t) {
   t.test('should return path for an auth like url', function (t) {
@@ -26,11 +26,39 @@ test('#getPathFromRequest', function (t) {
   })
 })
 
+test('#getApollo4Path', function (t) {
+  t.test('should return path for an auth like url', function (t) {
+    const req = createApolloRequest('https://test.com/graphql')
+    const path = getApollo4Path(req)
+    t.equals(path, '/graphql')
+    t.end()
+  })
+
+  t.test('should return / for missing parsedUrl field', function (t) {
+    const req = createRequest('https://test.com/foo/bar?query=value#hash')
+    const path = getApollo4Path(req)
+    t.equals(path, '/')
+    t.end()
+  })
+})
+
 function createRequest (url, host = 'example.com') {
   return {
     url: url,
     headers: {
       host: host
+    }
+  }
+}
+
+function createApolloRequest (url, host = 'example.com') {
+  return {
+    url: url,
+    headers: {
+      host: host
+    },
+    _parsedUrl: {
+      pathname: '/graphql'
     }
   }
 }


### PR DESCRIPTION
<!--
fix: added express support to apollo 4 support
- added new helper function to extract the path from apollo 4 requests (there is a breaking change in apollo server 4 that stores the path differently than in previous versions)
- added _apollo4 to the transaction to differentiate from other graphql requests
- in the graphql module, extract the path using the new helper function for apollo4 requests; use existing workflow for all other requests
- added unit test

-->

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [ ] Update TypeScript typings
- [ ] Update documentation
- [ ] Add CHANGELOG.asciidoc entry
- [ ] Commit message follows [commit guidelines](https://github.com/elastic/apm-agent-nodejs/blob/main/CONTRIBUTING.md#commit-message-guidelines)
